### PR TITLE
Add submodule `Controls`

### DIFF
--- a/docs/src/glossary.md
+++ b/docs/src/glossary.md
@@ -28,7 +28,7 @@ In an open quantum system, the structure of Eqs. (G1–G3) is the same, but wit
 
 ##### Operator
 
-A static, non-time-dependent object that can be multiplied to a state. An operator can be obtained from a time-dependent [Generator](@ref) by plugging in values for the controls and potentially any explicit time dependence. For example, an [`Operator`](@ref) is obtained from a [`Generator`](@ref) via [`evalcontrols`](@ref).
+A static, non-time-dependent object that can be multiplied to a state. An operator can be obtained from a time-dependent [Generator](@ref) by plugging in values for the controls and potentially any explicit time dependence. For example, an [`Operator`](@ref) is obtained from a [`Generator`](@ref) via [`QuantumControl.Controls.evalcontrols`](@ref).
 
 ----
 
@@ -96,7 +96,7 @@ More generally, the control parameters could also be spectral coefficients (CRAB
 
 ##### Pulse Parametrization
 
-A special case of a [Control Amplitude)(@ref) where ``a(t) = a(ϵ(t))`` at every point in time. The purpose of this is to constrain the amplitude of the control amplitude ``a(t)``. See e.g. [`SquareParametrization`](@ref), where ``a(t) = ϵ^2(t)`` to ensure that ``a(t)`` is positive. Since Krotov's method inherently has no constraints on the optimized control fields, pulse parameterization is a method of imposing constraints on the amplitude in this context.
+A special case of a [Control Amplitude)(@ref) where ``a(t) = a(ϵ(t))`` at every point in time. The purpose of this is to constrain the amplitude of the control amplitude ``a(t)``. See e.g. [`QuantumControl.PulseParametrizations.SquareParametrization`](@ref), where ``a(t) = ϵ^2(t)`` to ensure that ``a(t)`` is positive. Since Krotov's method inherently has no constraints on the optimized control fields, pulse parameterization is a method of imposing constraints on the amplitude in this context.
 
 ----
 

--- a/docs/src/manual.md
+++ b/docs/src/manual.md
@@ -23,7 +23,7 @@ Mathematically, the control problem is solved by minimizing a functional that is
 
 The controls that the `QuantumControl` package optimizes are implicit in the dynamical generator ([`hamiltonian`](@ref), [`liouvillian`](@ref)) of the [`Objectives`](@ref Objective) in the [`ControlProblem`](@ref).
 
-The [`QuantumControl.Generators.getcontrols`](@ref) method extracts the controls from the objectives. Each control is typically time-dependent, e.g., a function ``ϵ(t)`` or a vector of pulse values on a time grid. For each control, [`QuantumControl.Generators.discretize`](@ref) and [`QuantumControl.Generators.discretize_on_midpoints`](@ref) discretizes the control to an existing time grid. For controls that are implemented through some custom type, these methods must be defined to enable piecewise-constant time propagation or an optimization that assumes piecewise-constant control (most notably, Krotov's method).
+The [`QuantumControl.Controls.getcontrols`](@ref) method extracts the controls from the objectives. Each control is typically time-dependent, e.g., a function ``ϵ(t)`` or a vector of pulse values on a time grid. For each control, [`QuantumControl.Controls.discretize`](@ref) and [`QuantumControl.Controls.discretize_on_midpoints`](@ref) discretizes the control to an existing time grid. For controls that are implemented through some custom type, these methods must be defined to enable piecewise-constant time propagation or an optimization that assumes piecewise-constant control (most notably, Krotov's method).
 
 ## Time propagation
 

--- a/src/QuantumControl.jl
+++ b/src/QuantumControl.jl
@@ -8,6 +8,7 @@ using QuantumPropagators
 using QuantumControlBase
 @reexport_members(QuantumControlBase)
 
+
 module Generators
     # we need `QuantumPropagators.Generators` to be available under a name that
     # doesn't clash with `QuantumControl.Generators` in order for the
@@ -18,6 +19,33 @@ module Generators
     @reexport_members(QuantumPropagators_Generators)
 end
 
+
+module Controls
+    using QuantumPropagators: Controls as QuantumPropagators_Controls
+    using QuantumPropagators.Controls
+    include("reexport.jl")
+    @reexport_members(QuantumPropagators_Controls)
+    using QuantumControlBase: getcontrolderiv, getcontrolderivs
+    export getcontrolderiv, getcontrolderivs
+end
+
+
+module Shapes
+    using QuantumPropagators: Shapes as QuantumPropagators_Shapes
+    using QuantumPropagators.Shapes
+    include("reexport.jl")
+    @reexport_members(QuantumPropagators_Shapes)
+end
+
+
+module Amplitudes
+    using QuantumPropagators: Amplitudes as QuantumPropagators_Amplitudes
+    using QuantumPropagators.Amplitudes
+    include("reexport.jl")
+    @reexport_members(QuantumPropagators_Amplitudes)
+end
+
+
 module PulseParametrizations
     using QuantumControlBase: PulseParametrizations as QuantumControlBase_PulseParametrizations
     using QuantumControlBase.PulseParametrizations
@@ -25,19 +53,6 @@ module PulseParametrizations
     @reexport_members(QuantumControlBase_PulseParametrizations)
 end
 
-module Amplitudes
-    using QuantumControlBase: Amplitudes as QuantumControlBase_Amplitudes
-    using QuantumControlBase.Amplitudes
-    include("reexport.jl")
-    @reexport_members(QuantumControlBase_Amplitudes)
-end
-
-module Shapes
-    using QuantumControlBase: Shapes as QuantumControlBase_Shapes
-    using QuantumControlBase.Shapes
-    include("reexport.jl")
-    @reexport_members(QuantumControlBase_Shapes)
-end
 
 module Functionals
     using QuantumControlBase: Functionals as QuantumControlBase_Functionals

--- a/src/reexport.jl
+++ b/src/reexport.jl
@@ -2,7 +2,7 @@
 #
 # For one thing, `@reexport using QuantumControlBase` re-exports not just the
 # members of `QuantumControlBase`, but also `QuantumControlBase` itself. Also,
-# as far as I can tell `@reexport using QuantumControlBase.Shapes` does not
+# as far as I can tell `@reexport using QuantumPropagators.Shapes` does not
 # work when it's inside a module also called `Shapes`, as we're doing.
 #
 # Besides, the macro below is pretty trivial


### PR DESCRIPTION
The `Controls` submodule is split out from the `Generators` submodule. Adapts to refactoring/reorganization of `QuantumPropagators` / `QuantumControlBase`.