### PR TITLE
Expose refactoring

### DIFF
--- a/docs/src/manual.md
+++ b/docs/src/manual.md
@@ -23,7 +23,7 @@ Mathematically, the control problem is solved by minimizing a functional that is
 
 The controls that the `QuantumControl` package optimizes are implicit in the dynamical generator ([`hamiltonian`](@ref), [`liouvillian`](@ref)) of the [`Objectives`](@ref Objective) in the [`ControlProblem`](@ref).
 
-The [`QuantumControl.Controls.getcontrols`](@ref) method extracts the controls from the objectives. Each control is typically time-dependent, e.g., a function ``ϵ(t)`` or a vector of pulse values on a time grid. For each control, [`QuantumControl.Controls.discretize`](@ref) and [`QuantumControl.Controls.discretize_on_midpoints`](@ref) discretizes the control to an existing time grid. For controls that are implemented through some custom type, these methods must be defined to enable piecewise-constant time propagation or an optimization that assumes piecewise-constant control (most notably, Krotov's method).
+The [`QuantumControl.Controls.get_controls`](@ref) method extracts the controls from the objectives. Each control is typically time-dependent, e.g., a function ``ϵ(t)`` or a vector of pulse values on a time grid. For each control, [`QuantumControl.Controls.discretize`](@ref) and [`QuantumControl.Controls.discretize_on_midpoints`](@ref) discretizes the control to an existing time grid. For controls that are implemented through some custom type, these methods must be defined to enable piecewise-constant time propagation or an optimization that assumes piecewise-constant control (most notably, Krotov's method).
 
 ## Time propagation
 

--- a/src/QuantumControl.jl
+++ b/src/QuantumControl.jl
@@ -25,8 +25,8 @@ module Controls
     using QuantumPropagators.Controls
     include("reexport.jl")
     @reexport_members(QuantumPropagators_Controls)
-    using QuantumControlBase: getcontrolderiv, getcontrolderivs
-    export getcontrolderiv, getcontrolderivs
+    using QuantumControlBase: get_control_deriv, get_control_derivs
+    export get_control_deriv, get_control_derivs
 end
 
 


### PR DESCRIPTION
* `initprop` → `init_prop`
* `propstep!` → `prop_step!`
* `reinitprop!` → `reinit_prop!`
* `getcontrolderiv` → `get_control_deriv`
* `getcontrolderivs` → `get_control_derivs`
* `getcontrols` → `get_controls`

https://github.com/JuliaQuantumControl/QuantumPropagators.jl/pull/35 https://github.com/JuliaQuantumControl/QuantumControlBase.jl/pull/48