### PR TITLE
Add `save_optimization` function in workflows

### DIFF
--- a/src/QuantumControl.jl
+++ b/src/QuantumControl.jl
@@ -55,8 +55,8 @@ end
 
 
 include("workflows.jl")  # submodule Workflows
-using .Workflows: run_or_load, @optimize_or_load, load_optimization
-export run_or_load, @optimize_or_load, load_optimization
+using .Workflows: run_or_load, @optimize_or_load, save_optimization, load_optimization
+export run_or_load, @optimize_or_load, save_optimization, load_optimization
 
 include("pulse_parametrizations.jl")  # submodule PulseParametrizations
 

--- a/test/test_optimize_or_load.jl
+++ b/test/test_optimize_or_load.jl
@@ -1,6 +1,6 @@
 using Test
 
-using QuantumControl: @optimize_or_load, load_optimization, optimize
+using QuantumControl: @optimize_or_load, load_optimization, save_optimization, optimize
 using QuantumControlTestUtils.DummyOptimization:
     dummy_control_problem, DummyOptimizationResult
 
@@ -24,6 +24,15 @@ using QuantumControlTestUtils.DummyOptimization:
     @test result_load.message == "Reached maximum number of iterations"
     @test metadata["testset"] == "metadata"
     @test metadata["method"] == :dummymethod
+
+    outfile2 = joinpath(outdir, "optimization_with_metadata2.jld2")
+    save_optimization(outfile2, result_load; metadata)
+    @test isfile(outfile2)
+    result_load2, metadata2 = load_optimization(outfile2; return_metadata=true)
+    @test result_load2 isa DummyOptimizationResult
+    @test result_load2.message == "Reached maximum number of iterations"
+    @test metadata2["testset"] == "metadata"
+    @test metadata2["method"] == :dummymethod
 
 end
 


### PR DESCRIPTION
Although usually, `@optimize_or_load` is better, sometimes it's easiest to use `optimize` in the REPL, but then save the result manually.