### PR TITLE
Make `chi` functions not-in-place

### DIFF
--- a/docs/src/refs.bib
+++ b/docs/src/refs.bib
@@ -390,3 +390,13 @@
     Pages = {055012},
     Volume = {16},
 }
+
+@article{GoerzQ2022,
+    Author = {Goerz, Michael H. and Carrasco, Sebastián C. and Malinovsky, Vladimir S.},
+    Title = {Quantum Optimal Control via Semi-Automatic Differentiation},
+    Journal = quant,
+    Year = {2022},
+    Doi = {10.22331/q-2022-12-07-871},
+    Pages = {871},
+    Volume = {6},
+}

--- a/ext/QuantumControlFiniteDifferencesExt.jl
+++ b/ext/QuantumControlFiniteDifferencesExt.jl
@@ -8,22 +8,24 @@ import QuantumControl.Functionals: make_gate_chi
 
 function make_gate_chi(J_T_U, trajectories, ::Val{:FiniteDifferences}; kwargs...)
 
-    N = length(trajectories)
-    basis = [traj.initial_state for traj in trajectories]
-
-    function fdm_gate_chi!(χ, ϕ, trajectories; τ=nothing)
+    function fdm_gate_chi(Ψ, trajectories)
         function _J_T(U)
             -J_T_U(U; kwargs...)
         end
-        U = [basis[i] ⋅ ϕ[j] for i = 1:N, j = 1:N]
+        N = length(trajectories)
+        χ = Vector{eltype(Ψ)}(undef, N)
+        # We assume that that the initial states of the trajectories are the
+        # logical basis states
+        U = [trajectories[i].initial_state ⋅ Ψ[j] for i = 1:N, j = 1:N]
         fdm = FiniteDifferences.central_fdm(5, 1)
         ∇J = FiniteDifferences.grad(fdm, gate -> _J_T(gate), U)[1]
         for k = 1:N
-            χ[k] .= 0.5 * sum([∇J[i, k] * basis[i] for i = 1:N])
+            χ[k] = 0.5 * sum([∇J[i, k] * trajectories[i].initial_state for i = 1:N])
         end
+        return χ
     end
 
-    return fdm_gate_chi!
+    return fdm_gate_chi
 
 end
 

--- a/ext/QuantumControlZygoteExt.jl
+++ b/ext/QuantumControlZygoteExt.jl
@@ -8,21 +8,23 @@ import QuantumControl.Functionals: make_gate_chi
 
 function make_gate_chi(J_T_U, trajectories, ::Val{:Zygote}; kwargs...)
 
-    N = length(trajectories)
-    basis = [traj.initial_state for traj in trajectories]
-
-    function zygote_gate_chi!(χ, ϕ, trajectories; τ=nothing)
+    function zygote_gate_chi(Ψ, trajectories)
         function _J_T(U)
             -J_T_U(U; kwargs...)
         end
-        U = [basis[i] ⋅ ϕ[j] for i = 1:N, j = 1:N]
+        N = length(trajectories)
+        χ = Vector{eltype(Ψ)}(undef, N)
+        # We assume that that the initial states of the trajectories are the
+        # logical basis states
+        U = [trajectories[i].initial_state ⋅ Ψ[j] for i = 1:N, j = 1:N]
         ∇J = Zygote.gradient(gate -> _J_T(gate), U)[1]
         for k = 1:N
-            χ[k] .= 0.5 * sum([∇J[i, k] * basis[i] for i = 1:N])
+            χ[k] = 0.5 * sum([∇J[i, k] * trajectories[i].initial_state for i = 1:N])
         end
+        return χ
     end
 
-    return zygote_gate_chi!
+    return zygote_gate_chi
 
 end
 

--- a/test/test_functionals.jl
+++ b/test/test_functionals.jl
@@ -2,7 +2,7 @@ using Test
 using LinearAlgebra
 using QuantumControl: QuantumControl, Trajectory
 using QuantumControl.Functionals
-using QuantumControl.Functionals: chi_re!, chi_sm!, chi_ss!
+using QuantumControl.Functionals: chi_re, chi_sm, chi_ss
 using QuantumControlTestUtils.RandomObjects: random_state_vector
 using QuantumControlTestUtils.DummyOptimization: dummy_control_problem
 using TwoQubitWeylChamber: D_PE, gate_concurrence, unitarity
@@ -34,24 +34,22 @@ PROBLEM = dummy_control_problem(;
     # called with ϕ states or with τ values
 
     trajectories = PROBLEM.trajectories
-    χ1 = [similar(traj.initial_state) for traj in trajectories]
-    χ2 = [similar(traj.initial_state) for traj in trajectories]
-    ϕ = [random_state_vector(N_HILBERT; rng=RNG) for k = 1:N]
-    τ = [traj.target_state ⋅ ϕ[k] for (k, traj) in enumerate(trajectories)]
+    Ψ = [random_state_vector(N_HILBERT; rng=RNG) for k = 1:N]
+    τ = [traj.target_state ⋅ Ψ[k] for (k, traj) in enumerate(trajectories)]
 
-    @test J_T_re(ϕ, trajectories) ≈ J_T_re(nothing, trajectories; τ)
-    chi_re!(χ1, ϕ, trajectories)
-    chi_re!(χ2, ϕ, trajectories; τ=τ)
+    @test J_T_re(Ψ, trajectories) ≈ J_T_re(nothing, trajectories; τ)
+    χ1 = chi_re(Ψ, trajectories)
+    χ2 = chi_re(Ψ, trajectories; τ)
     @test maximum(norm.(χ1 .- χ2)) < 1e-12
 
-    @test J_T_sm(ϕ, trajectories) ≈ J_T_sm(nothing, trajectories; τ)
-    chi_sm!(χ1, ϕ, trajectories)
-    chi_sm!(χ2, ϕ, trajectories; τ=τ)
+    @test J_T_sm(Ψ, trajectories) ≈ J_T_sm(nothing, trajectories; τ)
+    χ1 = chi_sm(Ψ, trajectories)
+    χ2 = chi_sm(Ψ, trajectories; τ)
     @test maximum(norm.(χ1 .- χ2)) < 1e-12
 
-    @test J_T_ss(ϕ, trajectories) ≈ J_T_ss(nothing, trajectories; τ)
-    chi_ss!(χ1, ϕ, trajectories)
-    chi_ss!(χ2, ϕ, trajectories; τ=τ)
+    @test J_T_ss(Ψ, trajectories) ≈ J_T_ss(nothing, trajectories; τ)
+    χ1 = chi_ss(Ψ, trajectories)
+    χ2 = chi_ss(Ψ, trajectories; τ)
     @test maximum(norm.(χ1 .- χ2)) < 1e-12
 
 end
@@ -96,20 +94,18 @@ end
 
 
     J_T = gate_functional(J_T_C)
-    ϕ = transpose(CPHASE_lossy) * basis
+    Ψ = transpose(CPHASE_lossy) * basis
     trajectories = [Trajectory(Ψ, nothing) for Ψ ∈ basis]
-    @test J_T(ϕ, trajectories) ≈ J_T_C(CPHASE_lossy)
+    @test J_T(Ψ, trajectories) ≈ J_T_C(CPHASE_lossy)
 
-    chi_J_T! = make_chi(J_T, trajectories; mode=:automatic, automatic=Zygote)
-    χ = [similar(traj.initial_state) for traj in trajectories]
-    chi_J_T!(χ, ϕ, trajectories)
+    chi_J_T = make_chi(J_T, trajectories; mode=:automatic, automatic=Zygote)
+    χ = chi_J_T(Ψ, trajectories)
 
     J_T2 = gate_functional(J_T_C; w=0.1)
-    @test (J_T2(ϕ, trajectories) - J_T_C(CPHASE_lossy)) < -0.1
+    @test (J_T2(Ψ, trajectories) - J_T_C(CPHASE_lossy)) < -0.1
 
-    chi_J_T2! = make_chi(J_T2, trajectories; mode=:automatic, automatic=Zygote)
-    χ2 = [similar(traj.initial_state) for traj in trajectories]
-    chi_J_T2!(χ2, ϕ, trajectories)
+    chi_J_T2 = make_chi(J_T2, trajectories; mode=:automatic, automatic=Zygote)
+    χ2 = chi_J_T2(Ψ, trajectories)
 
     QuantumControl.set_default_ad_framework(nothing; quiet=true)
 
@@ -126,31 +122,27 @@ end
         make_gate_chi(J_T_C, trajectories)
     end
     @test contains(capture.output, "automatic with Zygote")
-    chi_J_T_C_zyg! = capture.value
-    χ_zyg = [similar(traj.initial_state) for traj in trajectories]
-    chi_J_T_C_zyg!(χ_zyg, ϕ, trajectories)
+    chi_J_T_C_zyg = capture.value
+    χ_zyg = chi_J_T_C_zyg(Ψ, trajectories)
 
     QuantumControl.set_default_ad_framework(FiniteDifferences; quiet=true)
     capture = IOCapture.capture() do
         make_gate_chi(J_T_C, trajectories)
     end
     @test contains(capture.output, "automatic with FiniteDifferences")
-    chi_J_T_C_fdm! = capture.value
-    χ_fdm = [similar(traj.initial_state) for traj in trajectories]
-    chi_J_T_C_fdm!(χ_fdm, ϕ, trajectories)
+    chi_J_T_C_fdm = capture.value
+    χ_fdm = chi_J_T_C_fdm(Ψ, trajectories)
 
     @test maximum(norm.(χ_zyg .- χ)) < 1e-12
     @test maximum(norm.(χ_zyg .- χ_fdm)) < 1e-12
 
     QuantumControl.set_default_ad_framework(nothing; quiet=true)
 
-    chi_J_T_C_zyg2! = make_gate_chi(J_T_C, trajectories; automatic=Zygote, w=0.1)
-    χ_zyg2 = [similar(traj.initial_state) for traj in trajectories]
-    chi_J_T_C_zyg2!(χ_zyg2, ϕ, trajectories)
+    chi_J_T_C_zyg2 = make_gate_chi(J_T_C, trajectories; automatic=Zygote, w=0.1)
+    χ_zyg2 = chi_J_T_C_zyg2(Ψ, trajectories)
 
-    chi_J_T_C_fdm2! = make_gate_chi(J_T_C, trajectories; automatic=FiniteDifferences, w=0.1)
-    χ_fdm2 = [similar(traj.initial_state) for traj in trajectories]
-    chi_J_T_C_fdm2!(χ_fdm2, ϕ, trajectories)
+    chi_J_T_C_fdm2 = make_gate_chi(J_T_C, trajectories; automatic=FiniteDifferences, w=0.1)
+    χ_fdm2 = chi_J_T_C_fdm2(Ψ, trajectories)
 
     @test maximum(norm.(χ_zyg2 .- χ2)) < 1e-12
     @test maximum(norm.(χ_zyg2 .- χ_fdm2)) < 1e-12

--- a/test/test_pulse_parameterizations.jl
+++ b/test/test_pulse_parameterizations.jl
@@ -189,7 +189,7 @@ end
     )
 
     captured = IOCapture.capture(passthrough=false) do
-        optimize(problem_tanh; method=Krotov)
+        optimize(problem_tanh; method=Krotov, rethrow_exceptions=true)
     end
     opt_result_tanh = captured.value
     @test opt_result_tanh.iter == 30


### PR DESCRIPTION
The `chi!` functions previously used by GRAPE and Krotov are now simply `chi` do not act in-place. This is more general and easier to implement for the user, as it allows to use immutable structs for states

Note that in extreme performance-critical situations, one could still construct the χ-states in-place via a closure or functor.

See also
https://github.com/JuliaQuantumControl/QuantumControlBase.jl/pull/85