### PR TITLE
Add support for state-dependent running costs

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -77,6 +77,7 @@ fallbacks = DocumenterInterLinks.ExternalFallbacks(
     "make_grape_print_iters" => "@extref GRAPE :jl:function:`GRAPE.make_grape_print_iters`",
     "GrapeWrk" => "@extref GRAPE :jl:type:`GRAPE.GrapeWrk`",
     "Operators" => "@extref QuantumPropagators :std:label:`Operators`",
+    "Overview-Running-Costs" => "@extref GRAPE :std:label:`Overview-Running-Costs`",
     automatic = false,
 )
 

--- a/ext/QuantumControlFiniteDifferencesExt.jl
+++ b/ext/QuantumControlFiniteDifferencesExt.jl
@@ -4,7 +4,7 @@ using LinearAlgebra
 
 import FiniteDifferences
 import QuantumControl.Functionals:
-    make_gate_chi, make_automatic_chi, make_automatic_grad_J_a
+    make_gate_chi, make_automatic_chi, make_automatic_grad_J_a, make_automatic_xi
 
 
 function make_automatic_chi(J_T, trajectories, ::Val{:FiniteDifferences}; via = :states)
@@ -97,6 +97,19 @@ function make_gate_chi(J_T_U, trajectories, ::Val{:FiniteDifferences}; kwargs...
 
     return fdm_gate_chi
 
+end
+
+
+function make_automatic_xi(g_b, ::Val{:FiniteDifferences})
+    function automatic_xi(Ψ, trajectory, tlist, n)
+        function _g_b(Ψ)
+            return g_b(Ψ, trajectory, tlist, n)
+        end
+        fdm = FiniteDifferences.central_fdm(5, 1)
+        grad = FiniteDifferences.grad(fdm, _g_b, Ψ)[1]
+        return -0.5 * grad
+    end
+    return automatic_xi
 end
 
 end

--- a/ext/QuantumControlZygoteExt.jl
+++ b/ext/QuantumControlZygoteExt.jl
@@ -4,7 +4,7 @@ using LinearAlgebra
 
 import Zygote
 import QuantumControl.Functionals:
-    make_gate_chi, make_automatic_chi, make_automatic_grad_J_a
+    make_gate_chi, make_automatic_chi, make_automatic_grad_J_a, make_automatic_xi
 
 
 function make_automatic_chi(J_T, trajectories, ::Val{:Zygote}; via = :states)
@@ -109,6 +109,22 @@ function make_gate_chi(J_T_U, trajectories, ::Val{:Zygote}; kwargs...)
 
     return zygote_gate_chi
 
+end
+
+
+function make_automatic_xi(g_b, ::Val{:Zygote})
+    function automatic_xi(Ψ, trajectory, tlist, n)
+        function _g_b(Ψ)
+            return g_b(Ψ, trajectory, tlist, n)
+        end
+        grad = Zygote.gradient(_g_b, Ψ)[1]
+        if isnothing(grad)
+            # g_b does not depend on Ψ
+            return zero(Ψ)
+        end
+        return -0.5 * grad
+    end
+    return automatic_xi
 end
 
 end

--- a/src/functionals.jl
+++ b/src/functionals.jl
@@ -4,9 +4,11 @@ export J_T_ss, J_T_sm, J_T_re
 export J_a_fluence
 export gate_functional
 export make_gate_chi
-export make_grad_J_a, make_chi
+export J_b
+export make_grad_J_a, make_chi, make_xi
 
 using LinearAlgebra: axpy!, dot
+using QuantumControl.QuantumPropagators.Storage: get_from_storage
 
 
 function _check_chi(chi; states, trajectories, tau, via)
@@ -372,10 +374,10 @@ grad_J_a = make_grad_J_a(
 )
 ```
 
-returns a function so that `∇J_a = grad_J_a(pulsevals, tlist)` sets
-that returns a vector `∇J_a` containing the vectorized elements
-``∂J_a/∂ϵ_{ln}``. The function `J_a` must have the interface `J_a(pulsevals,
-tlist)`, see, e.g., [`J_a_fluence`](@ref).
+returns a function so that `∇J_a = grad_J_a(pulsevals, tlist)` returns a
+vector `∇J_a` containing the vectorized elements ``∂J_a/∂ϵ_{ln}``.
+The function `J_a` must have the interface `J_a(pulsevals, tlist)`,
+see, e.g., [`J_a_fluence`](@ref).
 
 The parameters `mode` and `automatic` are handled as in [`make_chi`](@ref),
 where `mode` is one of `:any`, `:analytic`, `:automatic`, and `automatic` is
@@ -953,5 +955,186 @@ end
 
 
 make_analytic_grad_J_a(::typeof(J_a_fluence), tlist) = grad_J_a_fluence
+
+
+"""
+Return a function that calculates ``|ξ_k(t_n)⟩ = -∂g_b/∂⟨Ψ_k(t_n)|``.
+
+```julia
+xi = make_xi(g_b; mode=:any, automatic=:default)
+```
+
+returns a function `xi(Ψ, trajectory, tlist, n)` that evaluates
+
+```math
+|ξ_k(t_n)⟩ = -\\frac{∂ (g_b)_{kn}}{∂ ⟨Ψ_k(t_n)|}
+```
+
+where `g_b(Ψ, trajectory, tlist, n) -> Float64` is a per-trajectory,
+per-time-point running cost, cf. [`J_b`](@ref). Note the minus sign, which
+is included in the definition to match the minus sign in [`make_chi`](@ref).
+Both in `g_b` and `xi`, the argument `n` is a one-based index into the time
+grid `tlist`. Since a [`QuantumControl.Trajectory`](@ref) can contain arbitrary
+(custom) properties, a `g_b` function may reference such custom properties
+where appropriate, and `xi` will have access to the same `trajectory` as `g_b`
+itself.
+
+The `mode` and `automatic` parameters work as in
+[`QuantumControl.Functionals.make_chi`](@ref). With `mode=:any` (default),
+an analytic xi is used if available (via `make_analytic_xi`, see below),
+falling back to automatic differentiation otherwise. With `mode=:analytic`,
+only the analytic path is attempted. With `mode=:automatic`, only automatic
+differentiation is used.
+
+The `automatic` parameter specifies the AD backend module (or `:default` to
+use the framework set via [`QuantumControl.set_default_ad_framework`](@ref)). For
+example, with `automatic=Zygote` (loaded via `import Zygote`), `g_b` is
+differentiated with respect to `Ψ` using Wirtinger calculus:
+
+```julia
+xi(Ψ, ...) = -0.5 * Zygote.gradient(psi -> g_b(psi, ...), Ψ)[1]
+```
+
+!!! tip
+
+    In order to extend `make_xi` with an analytic implementation for a new
+    `g_b` function, define a new method `make_analytic_xi` like so:
+
+    ```julia
+    QuantumControl.Functionals.make_analytic_xi(::typeof(my_g_b)) = my_xi
+    ```
+
+    which links `make_xi` for a function `my_g_b` to `my_xi`.
+
+!!! warning
+
+    Zygote is notorious for being buggy (silently returning incorrect
+    gradients). Always test automatic derivatives against finite differences
+    and/or other automatic differentiation frameworks.
+"""
+function make_xi(g_b; mode = :any, automatic = :default)
+    if mode == :any
+        try
+            xi = make_analytic_xi(g_b)
+            @debug "make_xi for g_b=$(g_b) -> analytic"
+            return xi
+        catch exception
+            if exception isa MethodError
+                @info "make_xi for g_b=$(g_b): fallback to mode=:automatic"
+                try
+                    xi = make_automatic_xi(g_b, automatic)
+                    return xi
+                catch exception
+                    if exception isa MethodError
+                        msg = "make_xi for g_b=$(g_b): no analytic gradient, and no automatic gradient with `automatic=$(repr(automatic))`."
+                        error(msg)
+                    else
+                        rethrow()
+                    end
+                end
+            else
+                rethrow()
+            end
+        end
+    elseif mode == :analytic
+        try
+            xi = make_analytic_xi(g_b)
+            return xi
+        catch exception
+            if exception isa MethodError
+                msg = "make_xi for g_b=$(g_b): no analytic gradient. Implement `GRAPE.make_analytic_xi(::typeof(g_b))`"
+                error(msg)
+            else
+                rethrow()
+            end
+        end
+    elseif mode == :automatic
+        try
+            xi = make_automatic_xi(g_b, automatic)
+            return xi
+        catch exception
+            if exception isa MethodError
+                msg = "make_xi for g_b=$(g_b): no automatic gradient with `automatic=$(repr(automatic))`."
+                error(msg)
+            else
+                rethrow()
+            end
+        end
+    else
+        msg = "`mode=$(repr(mode))` must be one of :any, :analytic, :automatic"
+        throw(ArgumentError(msg))
+    end
+end
+
+
+# Generic placeholder
+function make_analytic_xi end
+
+
+# Module to Val{Symbol} dispatch
+function make_automatic_xi(g_b, automatic::Module)
+    return make_automatic_xi(g_b, Val(nameof(automatic)))
+end
+
+# Symbol to Val{Symbol} dispatch
+function make_automatic_xi(g_b, automatic::Symbol)
+    return make_automatic_xi(g_b, Val(automatic))
+end
+
+function make_automatic_xi(g_b, ::Val{:default})
+    if DEFAULT_AD_FRAMEWORK == :nothing
+        msg = "make_xi: no default `automatic`. You must run `QuantumControl.set_default_ad_framework` first, e.g. `import Zygote; QuantumControl.set_default_ad_framework(Zygote)`."
+        error(msg)
+    end
+    xi = make_automatic_xi(g_b, DEFAULT_AD_FRAMEWORK)
+    return xi
+end
+
+
+"""
+Evaluate a state-dependent running cost functional.
+
+```julia
+J_b_val = J_b(storage, trajectories, tlist; g_b)
+```
+
+returns
+
+```math
+J_b = ∑_k ∑_n g_b(|Ψ_k(t_n)⟩) Δt_n
+```
+
+as the piecewise-constant discretization of
+
+```math
+J_b = ∑_k \\int g_b(|Ψ_k(t)⟩) dt
+```
+
+where `storage[k]` contains the forward-propagated states for trajectory `k`
+at each point of `tlist`; for example, the `fw_storage` component of the
+[GRAPE workspace](@extref `GRAPE.GrapeWrk`). The ``Δt_n`` is the
+[time step around the time grid point ``t_n``](@extref GRAPE Overview-Running-Costs).
+
+Note that `g_b` is a mandatory keyword argument and must be a function
+`g_b(Ψ, trajectory, tlist, n) -> Float64`.
+"""
+function J_b(storage, trajectories, tlist; g_b)
+    N = length(trajectories)
+    result = 0.0
+    for k = 1:N
+        Ψ₁ = get_from_storage(storage[k], 1)
+        result += g_b(Ψ₁, trajectories[k], tlist, 1) * (tlist[2] - tlist[1])
+        for n_tl = 2:length(tlist)
+            Ψₙ = get_from_storage(storage[k], n_tl)
+            if n_tl < length(tlist)
+                dt = 0.5 * (tlist[n_tl+1] - tlist[n_tl-1])
+            else
+                dt = tlist[end] - tlist[end-1]
+            end
+            result += g_b(Ψₙ, trajectories[k], tlist, n_tl) * dt
+        end
+    end
+    return result
+end
 
 end

--- a/src/functionals.jl
+++ b/src/functionals.jl
@@ -1042,7 +1042,7 @@ function make_xi(g_b; mode = :any, automatic = :default)
             return xi
         catch exception
             if exception isa MethodError
-                msg = "make_xi for g_b=$(g_b): no analytic gradient. Implement `GRAPE.make_analytic_xi(::typeof(g_b))`"
+                msg = "make_xi for g_b=$(g_b): no analytic gradient. Implement `QuantumControl.Functionals.make_analytic_xi(::typeof(g_b))`"
                 error(msg)
             else
                 rethrow()

--- a/test/test_functionals.jl
+++ b/test/test_functionals.jl
@@ -25,6 +25,7 @@ using Zygote
 using GRAPE: GrapeWrk
 using FiniteDifferences
 using IOCapture
+using Logging
 
 const 𝕚 = 1im
 const ⊗ = kron
@@ -621,6 +622,147 @@ end
             @test norm(ξ_zyg - ξ_analytic) < 1e-12
             @test norm(ξ_fdm - ξ_analytic) < 1e-10
         end
+    end
+
+end
+
+
+@testset "make-xi (analytic path)" begin
+
+    # Register an analytic xi for a custom g_b function.
+    function g_b_with_xi(Ψ, traj, tlist, n)
+        return real(dot(Ψ, Ψ))
+    end
+    function xi_for_g_b(Ψ, traj, tlist, n)
+        return -Ψ
+    end
+    QuantumControl.Functionals.make_analytic_xi(::typeof(g_b_with_xi)) = xi_for_g_b
+
+    tlist = PROBLEM.tlist
+    Ψ = random_state_vector(N_HILBERT; rng = RNG)
+    traj = PROBLEM.trajectories[1]
+
+    xi = make_xi(g_b_with_xi; mode = :analytic)
+    @test xi ≡ xi_for_g_b
+    @test xi(Ψ, traj, tlist, 1) ≈ -Ψ
+
+    # mode=:any uses the analytic path and emits a @debug message
+    captured = IOCapture.capture() do
+        Logging.with_logger(Logging.ConsoleLogger(stderr, Logging.Debug)) do
+            make_xi(g_b_with_xi)
+        end
+    end
+    @test captured.value isa Function
+    @test contains(captured.output, "make_xi for g_b=")
+    @test contains(captured.output, "-> analytic")
+
+end
+
+
+@testset "g_b without analytic derivative" begin
+
+    QuantumControl.set_default_ad_framework(nothing; quiet = true)
+
+    function g_b_no_xi(Ψ, traj, tlist, n)
+        return real(dot(Ψ, Ψ))
+    end
+
+    captured = IOCapture.capture(rethrow = Union{}) do
+        make_xi(g_b_no_xi)
+    end
+    @test contains(captured.output, "fallback to mode=:automatic")
+    @test captured.value isa ErrorException
+    if captured.value isa ErrorException
+        @test contains(captured.value.msg, "no default `automatic`")
+    end
+
+    QuantumControl.set_default_ad_framework(Zygote; quiet = true)
+    captured = IOCapture.capture() do
+        make_xi(g_b_no_xi)
+    end
+    @test captured.value isa Function
+    @test contains(captured.output, "fallback to mode=:automatic")
+
+    captured = IOCapture.capture(rethrow = Union{}) do
+        make_xi(g_b_no_xi; mode = :analytic)
+    end
+    @test captured.value isa ErrorException
+    if captured.value isa ErrorException
+        @test contains(captured.value.msg, "no analytic gradient")
+    end
+
+    QuantumControl.set_default_ad_framework(nothing; quiet = true)
+
+end
+
+
+@testset "Unsupported AD Framework (make_xi)" begin
+
+    QuantumControl.set_default_ad_framework(UnsupportedADFramework; quiet = true)
+
+    function g_b_no_xi(Ψ, traj, tlist, n)
+        return real(dot(Ψ, Ψ))
+    end
+
+    captured = IOCapture.capture(rethrow = Union{}, passthrough = false) do
+        make_xi(g_b_no_xi)
+    end
+    @test contains(captured.output, "fallback to mode=:automatic")
+    @test captured.value isa ErrorException
+    if captured.value isa ErrorException
+        @test contains(
+            captured.value.msg,
+            "no analytic gradient, and no automatic gradient"
+        )
+    end
+
+    captured = IOCapture.capture(rethrow = Union{}, passthrough = false) do
+        make_xi(g_b_no_xi; automatic = UnsupportedADFramework)
+    end
+    @test contains(captured.output, "fallback to mode=:automatic")
+    @test captured.value isa ErrorException
+    if captured.value isa ErrorException
+        @test contains(
+            captured.value.msg,
+            "no analytic gradient, and no automatic gradient"
+        )
+    end
+
+    captured = IOCapture.capture(rethrow = Union{}, passthrough = false) do
+        make_xi(g_b_no_xi; mode = :automatic, automatic = UnsupportedADFramework)
+    end
+    @test captured.value isa ErrorException
+    if captured.value isa ErrorException
+        @test contains(captured.value.msg, "no automatic gradient")
+    end
+
+    QuantumControl.set_default_ad_framework(nothing; quiet = true)
+
+end
+
+
+@testset "make-xi (invalid g_b interface)" begin
+
+    # A g_b with wrong signature: only takes Ψ, not (Ψ, traj, tlist, n).
+    function bad_g_b(Ψ)
+        return 1.0
+    end
+
+    # make_xi itself succeeds (no interface validation at construction time)
+    xi_bad = make_xi(bad_g_b; mode = :automatic, automatic = Zygote)
+    @test xi_bad isa Function
+
+    tlist = PROBLEM.tlist
+    traj = PROBLEM.trajectories[1]
+    Ψ = random_state_vector(N_HILBERT; rng = RNG)
+
+    # Calling the returned xi fails because g_b has the wrong interface
+    captured = IOCapture.capture(rethrow = Union{}) do
+        xi_bad(Ψ, traj, tlist, 1)
+    end
+    @test captured.value isa MethodError
+    if captured.value isa MethodError
+        @test contains(sprint(showerror, captured.value), "bad_g_b")
     end
 
 end

--- a/test/test_functionals.jl
+++ b/test/test_functionals.jl
@@ -9,12 +9,15 @@ using QuantumControl.Functionals:
     grad_J_a_fluence,
     make_grad_J_a,
     make_chi,
+    make_xi,
+    J_b,
     chi_re,
     chi_sm,
     chi_ss,
     gate_functional,
     make_gate_chi
-using QuantumControlTestUtils.RandomObjects: random_state_vector
+using QuantumControlTestUtils.RandomObjects: random_state_vector, random_dynamic_generator
+using QuantumPropagators.Controls: evaluate
 using QuantumControlTestUtils.DummyOptimization: dummy_control_problem
 using TwoQubitWeylChamber: D_PE, gate_concurrence, unitarity
 using StableRNGs: StableRNG
@@ -441,6 +444,7 @@ end
     QuantumControl.set_default_ad_framework(nothing; quiet = true)
 
     chi_J_T_C_zyg2 = make_gate_chi(J_T_C, trajectories; automatic = Zygote, w = 0.1)
+
     χ_zyg2 = chi_J_T_C_zyg2(Ψ, trajectories)
 
     chi_J_T_C_fdm2 =
@@ -449,5 +453,224 @@ end
 
     @test maximum(norm.(χ_zyg2 .- χ2)) < 1e-12
     @test maximum(norm.(χ_zyg2 .- χ_fdm2)) < 1e-12
+
+end
+
+
+@testset "make-xi" begin
+
+    # Test that make_xi via Zygote and FiniteDifferences both match the known
+    # analytic derivative for g_b(Ψ, traj, tlist, n) = real(⟨Ψ|traj.D|Ψ⟩),
+    # which has analytic xi = -∂g_b/∂⟨Ψ| = -traj.D|Ψ⟩.
+    # Each trajectory carries its own distinct D matrix as a custom property,
+    # verifying that xi correctly closes over `traj` and not just `Ψ`.
+
+    tlist = PROBLEM.tlist
+    Ψ = [random_state_vector(N_HILBERT; rng = RNG) for k = 1:N]
+
+    # Build trajectories with per-trajectory positive-semidefinite D matrices
+    trajectories = [
+        Trajectory(
+            traj.initial_state,
+            traj.generator;
+            target_state = traj.target_state,
+            D = let A = randn(RNG, ComplexF64, N_HILBERT, N_HILBERT)
+                A * A' / N_HILBERT
+            end
+        ) for traj in PROBLEM.trajectories
+    ]
+    # Confirm D matrices are genuinely distinct across trajectories
+    @test norm(trajectories[1].D - trajectories[2].D) > 1e-2
+
+    function g_b(Ψ, traj, tlist, n)
+        return real(dot(Ψ, traj.D * Ψ))
+    end
+
+    xi_zyg = make_xi(g_b; mode = :automatic, automatic = Zygote)
+    xi_fdm = make_xi(g_b; mode = :automatic, automatic = FiniteDifferences)
+
+    for k = 1:N
+        ξ_analytic = -trajectories[k].D * Ψ[k]
+        ξ_zyg = xi_zyg(Ψ[k], trajectories[k], tlist, 1)
+        ξ_fdm = xi_fdm(Ψ[k], trajectories[k], tlist, 1)
+        @test norm(ξ_zyg - ξ_analytic) < 1e-12
+        @test norm(ξ_fdm - ξ_analytic) < 1e-10
+    end
+
+    # make_xi with mode=:any falls back to :automatic when no analytic xi exists
+    QuantumControl.set_default_ad_framework(Zygote; quiet = true)
+    capture = IOCapture.capture() do
+        make_xi(g_b)
+    end
+    @test capture.value isa Function
+    @test contains(capture.output, "fallback to mode=:automatic")
+    QuantumControl.set_default_ad_framework(nothing; quiet = true)
+
+    # make_xi with mode=:analytic errors when no analytic xi is implemented
+    capture = IOCapture.capture(rethrow = Union{}) do
+        make_xi(g_b; mode = :analytic)
+    end
+    @test capture.value isa ErrorException
+    if capture.value isa ErrorException
+        @test contains(capture.value.msg, "no analytic gradient")
+    end
+
+end
+
+
+@testset "make-xi (time-dependent-discrete D)" begin
+
+    tlist = PROBLEM.tlist
+    N_intervals = length(tlist) - 1
+    Ψ = [random_state_vector(N_HILBERT; rng = RNG) for k = 1:N]
+
+    trajectories = [
+        Trajectory(
+            traj.initial_state,
+            traj.generator;
+            target_state = traj.target_state,
+            D = let H = random_dynamic_generator(
+                    N_HILBERT,
+                    tlist;
+                    rng = RNG,
+                    hermitian = true,
+                    complex = true,
+                )
+                D_int = [Array(evaluate(H, tlist, n)) for n = 1:N_intervals]
+                D_tl = Vector{Matrix{ComplexF64}}(undef, length(tlist))
+                # We use the same interpolation method as in `discretize` for
+                # converting between controls on the intervals of the time
+                # grid to controls on the time grid points
+                D_tl[1] = D_int[1]
+                D_tl[end] = D_int[end]
+                for n = 2:N_intervals
+                    D_tl[n] = 0.5 .* (D_int[n-1] .+ D_int[n])
+                end
+                D_tl
+            end
+        ) for traj in PROBLEM.trajectories
+    ]
+    # D varies across trajectories and across time steps within a trajectory
+    @test norm(trajectories[1].D[1] - trajectories[2].D[1]) > 1e-2
+    @test norm(trajectories[1].D[1] - trajectories[1].D[end]) > 1e-2
+
+    function g_b_td(Ψ, traj, tlist, n)
+        return real(dot(Ψ, traj.D[n] * Ψ))
+    end
+
+    xi_zyg = make_xi(g_b_td; mode = :automatic, automatic = Zygote)
+    xi_fdm = make_xi(g_b_td; mode = :automatic, automatic = FiniteDifferences)
+
+    # Check several time points including the first and last
+    for k = 1:N
+        for n in [1, length(tlist) ÷ 2, length(tlist)]
+            ξ_analytic = -trajectories[k].D[n] * Ψ[k]
+            ξ_zyg = xi_zyg(Ψ[k], trajectories[k], tlist, n)
+            ξ_fdm = xi_fdm(Ψ[k], trajectories[k], tlist, n)
+            @test norm(ξ_zyg - ξ_analytic) < 1e-12
+            @test norm(ξ_fdm - ξ_analytic) < 1e-10
+        end
+    end
+
+end
+
+
+@testset "make-xi (time-dependent-continuous D)" begin
+
+    # Each trajectory has two random Hermitian matrices D1 and D2.
+    # The operator D(t) = cos(t)² D1 + sin(t)² D2 is a smooth, Hermitian
+    # combination that varies continuously over time (the coefficients form a
+    # partition of unity: cos²+sin²=1). g_b uses tlist[n] directly to evaluate
+    # the analytic formula. The analytic xi is -(cos(t)² D1 + sin(t)² D2)|Ψ⟩.
+
+    tlist = PROBLEM.tlist
+    Ψ = [random_state_vector(N_HILBERT; rng = RNG) for k = 1:N]
+
+    trajectories = [
+        Trajectory(
+            traj.initial_state,
+            traj.generator;
+            target_state = traj.target_state,
+            D1 = let A = randn(RNG, ComplexF64, N_HILBERT, N_HILBERT)
+                A + A'
+            end,
+            D2 = let A = randn(RNG, ComplexF64, N_HILBERT, N_HILBERT)
+                A + A'
+            end,
+        ) for traj in PROBLEM.trajectories
+    ]
+    @test norm(trajectories[1].D1 - trajectories[2].D1) > 1e-2
+    @test norm(trajectories[1].D1 - trajectories[1].D2) > 1e-2
+
+    function g_b_analytic_td(Ψ, traj, tlist, n)
+        t = tlist[n]
+        D = cos(t)^2 * traj.D1 + sin(t)^2 * traj.D2
+        return real(dot(Ψ, D * Ψ))
+    end
+
+    xi_zyg = make_xi(g_b_analytic_td; mode = :automatic, automatic = Zygote)
+    xi_fdm = make_xi(g_b_analytic_td; mode = :automatic, automatic = FiniteDifferences)
+
+    for k = 1:N
+        for n in [1, length(tlist) ÷ 2, length(tlist)]
+            t = tlist[n]
+            D = cos(t)^2 * trajectories[k].D1 + sin(t)^2 * trajectories[k].D2
+            ξ_analytic = -D * Ψ[k]
+            ξ_zyg = xi_zyg(Ψ[k], trajectories[k], tlist, n)
+            ξ_fdm = xi_fdm(Ψ[k], trajectories[k], tlist, n)
+            @test norm(ξ_zyg - ξ_analytic) < 1e-12
+            @test norm(ξ_fdm - ξ_analytic) < 1e-10
+        end
+    end
+
+end
+
+
+@testset "J_b" begin
+
+    # Test that J_b correctly integrates g_b over all trajectories and time.
+    # Uses simple storage (vector of vectors) and a constant g_b = 1 whose
+    # integral is fully determined by the time grid and number of trajectories.
+
+    tlist = PROBLEM.tlist
+    trajectories = PROBLEM.trajectories
+    N_tl = length(tlist)
+
+    # Build fake storage: each trajectory gets a vector of random states
+    storage = [[random_state_vector(N_HILBERT; rng = RNG) for _ = 1:N_tl] for _ = 1:N]
+
+    function g_b_const(Ψ, traj, tlist, n)
+        return 1.0
+    end
+
+    J_b_val = J_b(storage, trajectories, tlist; g_b = g_b_const)
+
+    # Manually reproduce J_b's integration weights for a constant g_b = 1
+    expected = 0.0
+    for _ = 1:N
+        expected += tlist[2] - tlist[1]
+        for n_tl = 2:(N_tl-1)
+            expected += 0.5 * (tlist[n_tl+1] - tlist[n_tl-1])
+        end
+        expected += tlist[end] - tlist[end-1]
+    end
+    @test J_b_val ≈ expected
+
+    # With g_b ∝ n, J_b should reflect the weighted sum over time indices
+    function g_b_index(Ψ, traj, tlist, n)
+        return Float64(n)
+    end
+
+    J_b_idx = J_b(storage, trajectories, tlist; g_b = g_b_index)
+
+    expected_idx = 0.0
+    for _ = 1:N
+        expected_idx += 1.0 * (tlist[2] - tlist[1])
+        for n_tl = 2:(N_tl-1)
+            expected_idx += n_tl * 0.5 * (tlist[n_tl+1] - tlist[n_tl-1])
+        end
+        expected_idx += N_tl * (tlist[end] - tlist[end-1])
+    end
+    @test J_b_idx ≈ expected_idx
 
 end


### PR DESCRIPTION
Adds `make_xi` and `J_b` functions in `QuantumControl.Functionals`, with support for automatic differentiation.

This is a pre-requisite for state-dependent-running costs in GRAPE, see https://github.com/JuliaQuantumControl/GRAPE.jl/issues/53